### PR TITLE
fix: activation of multiple sockets fails on 64-bit platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+example/example

--- a/launchd.go
+++ b/launchd.go
@@ -15,7 +15,7 @@ func Files(name string) ([]*os.File, error) {
 	}
 	files := make([]*os.File, len(fds))
 	for idx, fd := range fds {
-		files[idx] = os.NewFile(uintptr(fd), "")
+		files[idx] = os.NewFile(fd, "")
 	}
 	return files, nil
 }
@@ -44,7 +44,7 @@ func Activate(name string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	} else if len(listeners) != 1 {
-		return nil, syscall.EINVAL
+		return nil, fmt.Errorf("too many sockets: %v: %w", len(listeners), syscall.EINVAL)
 	}
 	return listeners[0], nil
 }

--- a/libxpc.go
+++ b/libxpc.go
@@ -21,7 +21,7 @@ var libxpc_launch_activate_socket_trampoline_addr uintptr
 //go:cgo_import_dynamic libxpc_launch_activate_socket launch_activate_socket "/usr/lib/system/libxpc.dylib"
 
 // invokes launch_activate_socket
-func libxpc_launch_activate_socket(name string) ([]int, error) {
+func libxpc_launch_activate_socket(name string) ([]uintptr, error) {
 	c_name_ptr, err := syscall.BytePtrFromString(name)
 	if err != nil {
 		return nil, err
@@ -45,8 +45,10 @@ func libxpc_launch_activate_socket(name string) ([]int, error) {
 	} else if c_cnt > maxFDs {
 		return nil, syscall.EINVAL
 	}
-	c_fds := (*[maxFDs]int)(unsafe.Pointer(c_fds_ptr))
-	fds := make([]int, c_cnt)
-	copy(fds, (*c_fds)[0:c_cnt])
+	c_fds := (*[maxFDs]int32)(unsafe.Pointer(c_fds_ptr))
+	fds := make([]uintptr, c_cnt)
+	for idx, fd := range c_fds[0:c_cnt] {
+		fds[idx] = uintptr(fd)
+	}
 	return fds, nil
 }


### PR DESCRIPTION
Thanks for the useful module!

Problem:

The underlying `libxpc_launch_activate_socket_trampoline` call returns
an array of C `int`s which are 4 bytes each (32 bit).  On 64 bit
architectures go's `int`s are 8 bytes each.

Solution:

Fix the type of `libxpc_launch_activate_socket()`s `c_fds` and switch
from `copy()`ing the whole array (since it doesn't actually match the
size of `fds`) to a `for` loop.  Since they're now different types
anyway, have it return `uintptr`s so they don't need to be cast later
on.

Background:

I believe the existing `libxpc_launch_activate_socket()` code mostly
works when a single socket is returned because it copies past the end of
the `c_fds` array when it fills the `fds` array and then later the
various go syscalls all cast back to `int32` which drop the garbage,
most significant 4 bytes (if the most significant garbage bit happend to
be 1 this would fail becuase the final `int32` would be negative, but in
practice the garbage bytes seem to be 0).

I noticed this when I deleted the `SockFamily` key from
"example/agent.plist".  This caused `launchd` to return 2 sockets.  I
was expecting `launchd.Activate()` to fail with `syscall.EINVAL` but
instead its internal `launchd.Sockets()` failed with:
> 2024/12/20 13:40:35 launchd.Socket failed: net.FileListener for 0
> failed: file file+net : getsockopt: socket operation on non-socket

This is because `fds` ended up being filled with: `[17179869187, 0]`.
That is: `fd[0] == 0x400000003` (which contains both the actual file
descriptors: 3 and 4) and `fd[1] == 0` (which is all garbage, but seems
to be 0s in practice).  `Sockets()` would actually successfully pass
that `fd[0]` through `net.FileListener()` (because it would truncate
down to fd 3), but then `fd[1]` would fail in `getsockopt()` because 0
is stdin's file descriptor and it's not a socket.

After these changes, running the example without `SockFamily` fails
(correctly) with:
> 2024/12/20 15:46:15 launchd.Socket failed: too many sockets: 2:
> invalid argument
