### PR TITLE
fix: call file.Close() in Sockets()

### DIFF
--- a/launchd.go
+++ b/launchd.go
@@ -32,6 +32,7 @@ func Sockets(name string) ([]net.Listener, error) {
 		if err != nil {
 			return nil, fmt.Errorf("net.FileListener for %d failed: %w", file.Fd(), err)
 		}
+		file.Close()
 		listeners[idx] = listener
 	}
 	return listeners, nil


### PR DESCRIPTION
`net.FileListener()` makes its own dup so `file` can be `Close()`d immediately after.  The `files` are all unreachable after `Sockets()` returns so they will be `Close()`d eventually by their finalizers when GC eventaully runs, but I've got a use case where there isn't much GC churn and the extra file descriptor lingers around for a while and it's caused me a bit of headache when doing some debugging.

In theory `Close()`s could also be added to the various error paths in `Files()`, `Sockets()`, and `Activate()`, but that would add a bit of complexity to the code and I didn't find it immediately beneficial.